### PR TITLE
PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 language: php
 sudo: false
-dist: trusty
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
     - 7.1
     - 7.2
-
-matrix:
-  include:
-    - php: "5.3"
-      dist: precise
-    - php: "7.3"
+    - 7.3
+    - 7.4
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.2 || >=7.0 <7.4",
+        "php": "^5.3.2 || >=7.0",
         "symfony/dependency-injection": "^2.3|^3.0|^4.0@beta"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.2 || >=7.0",
+        "php": ">=7.0",
         "symfony/dependency-injection": "^2.3|^3.0|^4.0@beta"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds PHP 7.4 support.

Tests (`vendor/bin/phpunit`) run fine and are all green but they trigger a deprecation warning because of the dated PHPUnit version required.

> PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in /Volumes/Data/Projects/others/dependency-injection-extra/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38

This should close #3 